### PR TITLE
[HEALTH-5208] Add support in ObjectiveAvro to read avro files

### DIFF
--- a/Avro-C/src/codec.c
+++ b/Avro-C/src/codec.c
@@ -25,9 +25,9 @@
 #    include <byteswap.h>
 #  endif
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 #include <zlib.h>
-//#endif
+#endif
 #ifdef LZMA_CODEC
 #include <lzma.h>
 #endif
@@ -188,7 +188,7 @@ static int reset_snappy(avro_codec_t c)
 
 /* Deflate codec */
 
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 
 struct codec_data_deflate {
 	z_stream deflate;
@@ -378,7 +378,7 @@ static int reset_deflate(avro_codec_t c)
 	return 0;
 }
 
-//#endif // DEFLATE_CODEC
+#endif // DEFLATE_CODEC
 
 /* LZMA codec */
 
@@ -524,11 +524,11 @@ int avro_codec(avro_codec_t codec, const char *type)
 	}
 #endif
 
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	if (strcmp("deflate", type) == 0) {
 		return codec_deflate(codec);
 	}
-//#endif
+#endif
 
 #ifdef LZMA_CODEC
 	if (strcmp("lzma", type) == 0) {
@@ -554,10 +554,10 @@ int avro_codec_encode(avro_codec_t c, void * data, int64_t len)
 	case AVRO_CODEC_SNAPPY:
 		return encode_snappy(c, data, len);
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return encode_deflate(c, data, len);
-//#endif
+#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return encode_lzma(c, data, len);
@@ -577,10 +577,10 @@ int avro_codec_decode(avro_codec_t c, void * data, int64_t len)
 	case AVRO_CODEC_SNAPPY:
 		return decode_snappy(c, data, len);
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return decode_deflate(c, data, len);
-//#endif
+#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return decode_lzma(c, data, len);
@@ -600,10 +600,10 @@ int avro_codec_reset(avro_codec_t c)
 	case AVRO_CODEC_SNAPPY:
 		return reset_snappy(c);
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return reset_deflate(c);
-//#endif
+#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return reset_lzma(c);

--- a/Classes/OAVAvroSerialization.h
+++ b/Classes/OAVAvroSerialization.h
@@ -114,7 +114,7 @@ typedef void * OAVFileWriterToken;
 *  @param filePath  fiel path to saved avro file
 *  @param error      A pointer to the error object that will represent any errors ocurred
 *
-*  @return A Foundation representation of the Avro encoded object
+*  @return An array of json strings
 */
 - (NSArray *)JSONObjectsFromFile:(NSString *)filePath error:(NSError * __autoreleasing *)error;
 

--- a/Classes/OAVAvroSerialization.h
+++ b/Classes/OAVAvroSerialization.h
@@ -109,6 +109,16 @@ typedef void * OAVFileWriterToken;
                    error:( NSError * _Nullable  __autoreleasing *)error;
 
 /**
+*  Creates a Foundation object from Avro written file.
+*
+*  @param filePath  fiel path to saved avro file
+*  @param error      A pointer to the error object that will represent any errors ocurred
+*
+*  @return A Foundation representation of the Avro encoded object
+*/
+- (NSArray *)JSONObjectsFromFile:(NSString *)filePath error:(NSError * __autoreleasing *)error;
+
+/**
  *  Register a schema so the wrapper can serialize objects later.
  *
  *  @param schema A JSON describing the Avro schema

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -83,7 +83,7 @@
     }
     
     avro_file_writer_t writer = NULL;
-    if (avro_file_writer_create_with_codec([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer, "deflate", 0) != 0) {
+    if (avro_file_writer_create([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer) != 0) {
         if (error != NULL) {
             NSString *errorMsg = [NSString stringWithFormat:@"Couldn't create file writer: %s (%d)", avro_strerror(), errno];
             NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedStringFromTable(errorMsg, @"ObjectiveAvro", nil)};

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -83,7 +83,7 @@
     }
     
     avro_file_writer_t writer = NULL;
-    if (avro_file_writer_create([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer) != 0) {
+    if (avro_file_writer_create_with_codec([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer, "deflate", 0) != 0) {
         if (error != NULL) {
             NSString *errorMsg = [NSString stringWithFormat:@"Couldn't create file writer: %s (%d)", avro_strerror(), errno];
             NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedStringFromTable(errorMsg, @"ObjectiveAvro", nil)};

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -238,7 +238,7 @@
     
     char buf[[data length]];
     [data getBytes:&buf length:[data length]];
-    
+
     avro_reader_t reader = avro_reader_memory(buf, sizeof(buf));
     avro_datum_t datum_out;
     
@@ -260,6 +260,65 @@
                                                    options:0 error:error];
     return jsonValue;
 }
+
+- (NSArray *)JSONObjectsFromFile:(NSString *)filePath error:(NSError * __autoreleasing *)error {
+    
+    avro_file_reader_t  reader;
+    int errno;
+    char *filename = [filePath cStringUsingEncoding:NSUTF8StringEncoding];
+    
+    void (^reportError)(NSString* format, char* avro_message, int errono) = ^(NSString* format, char* avro_message, int errono) {
+        if (error != NULL) {
+            NSString *errorMsg = [NSString stringWithFormat:format, avro_strerror(), errono];
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedStringFromTable(errorMsg, @"ObjectiveAvro", nil)};
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadNoSuchFileError
+                                     userInfo:userInfo];
+        }
+    };
+
+    
+    if (errno = avro_file_reader(filename, &reader)) {
+        reportError(@"Couldn't open file reader: %s %d", avro_strerror(),errno);
+        return nil;
+    }
+
+    avro_schema_t  wschema;
+    avro_value_iface_t  *iface;
+    avro_value_t  value;
+
+    wschema = avro_file_reader_get_writer_schema(reader);
+    iface = avro_generic_class_from_schema(wschema);
+    avro_generic_value_new(iface, &value);
+
+    int rval;
+    NSMutableArray* serializedAvro = [NSMutableArray array];
+    while ((rval = avro_file_reader_read_value(reader, &value)) == 0) {
+        char  *json;
+
+        if (errno = avro_value_to_json(&value, 1, &json)) {
+            reportError(@"Error converting value to JSON: %s", avro_strerror(),errno);
+            return nil;
+        }
+        [serializedAvro addObject:[NSString stringWithUTF8String:json]];
+        avro_value_reset(&value);
+        free(json);
+    }
+
+    // If it was not an EOF that caused it to fail,
+    // print the error.
+    if (rval != EOF) {
+        reportError(@"END of file error: %s %d", avro_strerror(),errno);
+        return nil;
+    }
+
+    avro_file_reader_close(reader);
+    avro_value_decref(&value);
+    avro_value_iface_decref(iface);
+    avro_schema_decref(wschema);
+
+    return serializedAvro;
+}
+
 
 - (BOOL)registerSchema:(NSString *)schema error:(NSError * __autoreleasing *)error {
     NSParameterAssert(schema);

--- a/Example/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/Example/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -209,8 +209,6 @@
 				D476EB9F18D332AB0060579C /* Sources */,
 				D476EBA018D332AB0060579C /* Frameworks */,
 				D476EBA118D332AB0060579C /* Resources */,
-				E840297798744A91B4B55D09 /* [CP] Copy Pods Resources */,
-				9AE2F935AC2EF6C56B9A8733 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -228,7 +226,7 @@
 		D476EB7A18D332AB0060579C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Movile;
 				TargetAttributes = {
 					D476EBA218D332AB0060579C = {
@@ -241,6 +239,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -296,36 +295,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9AE2F935AC2EF6C56B9A8733 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E840297798744A91B4B55D09 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -391,6 +360,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -399,12 +369,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -441,6 +413,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -449,12 +422,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -525,6 +500,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"DEFLATE_CODEC=1",
 				);
 				INFOPLIST_FILE = "ObjectiveAvroTests/ObjectiveAvroTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.movile.${PRODUCT_NAME:rfc1034identifier}";

--- a/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -84,7 +84,22 @@
 		1ABFE40B1B695B15003B38D8 /* utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ABFE3FC1B695B15003B38D8 /* utf.c */; };
 		1ABFE40C1B695B15003B38D8 /* utf.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ABFE3FD1B695B15003B38D8 /* utf.h */; };
 		1ABFE40D1B695B15003B38D8 /* value.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ABFE3FE1B695B15003B38D8 /* value.c */; };
+		98574AF62566D4B2004A2488 /* ObjectiveAvroTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98574AF52566D4B2004A2488 /* ObjectiveAvroTests.m */; };
+		98574AF82566D4B2004A2488 /* ObjectiveAvro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */; };
+		98574B012566D7F1004A2488 /* people.json in Resources */ = {isa = PBXBuildFile; fileRef = 98574AFE2566D7F1004A2488 /* people.json */; };
+		98574B022566D7F1004A2488 /* people_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 98574AFF2566D7F1004A2488 /* people_schema.json */; };
+		98574B032566D7F1004A2488 /* person_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 98574B002566D7F1004A2488 /* person_schema.json */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		98574AF92566D4B2004A2488 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1ABFE33A1B69578B003B38D8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1ABFE3421B69578B003B38D8;
+			remoteInfo = ObjectiveAvro;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectiveAvro.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -166,6 +181,12 @@
 		1ABFE3FC1B695B15003B38D8 /* utf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf.c; sourceTree = "<group>"; };
 		1ABFE3FD1B695B15003B38D8 /* utf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf.h; sourceTree = "<group>"; };
 		1ABFE3FE1B695B15003B38D8 /* value.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = value.c; sourceTree = "<group>"; };
+		98574AF32566D4B2004A2488 /* ObjectiveAvroTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveAvroTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		98574AF52566D4B2004A2488 /* ObjectiveAvroTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveAvroTests.m; sourceTree = "<group>"; };
+		98574AF72566D4B2004A2488 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		98574AFE2566D7F1004A2488 /* people.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = people.json; sourceTree = "<group>"; };
+		98574AFF2566D7F1004A2488 /* people_schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = people_schema.json; sourceTree = "<group>"; };
+		98574B002566D7F1004A2488 /* person_schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = person_schema.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +197,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		98574AF02566D4B2004A2488 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				98574AF82566D4B2004A2488 /* ObjectiveAvro.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -183,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				1ABFE3451B69578B003B38D8 /* ObjectiveAvro */,
+				98574AF42566D4B2004A2488 /* ObjectiveAvroTests */,
 				1ABFE3441B69578B003B38D8 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -191,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */,
+				98574AF32566D4B2004A2488 /* ObjectiveAvroTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -339,6 +370,18 @@
 			path = src;
 			sourceTree = "<group>";
 		};
+		98574AF42566D4B2004A2488 /* ObjectiveAvroTests */ = {
+			isa = PBXGroup;
+			children = (
+				98574AFF2566D7F1004A2488 /* people_schema.json */,
+				98574AFE2566D7F1004A2488 /* people.json */,
+				98574B002566D7F1004A2488 /* person_schema.json */,
+				98574AF52566D4B2004A2488 /* ObjectiveAvroTests.m */,
+				98574AF72566D4B2004A2488 /* Info.plist */,
+			);
+			path = ObjectiveAvroTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -402,6 +445,24 @@
 			productReference = 1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		98574AF22566D4B2004A2488 /* ObjectiveAvroTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 98574AFD2566D4B2004A2488 /* Build configuration list for PBXNativeTarget "ObjectiveAvroTests" */;
+			buildPhases = (
+				98574AEF2566D4B2004A2488 /* Sources */,
+				98574AF02566D4B2004A2488 /* Frameworks */,
+				98574AF12566D4B2004A2488 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				98574AFA2566D4B2004A2488 /* PBXTargetDependency */,
+			);
+			name = ObjectiveAvroTests;
+			productName = ObjectiveAvroTests;
+			productReference = 98574AF32566D4B2004A2488 /* ObjectiveAvroTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -414,6 +475,11 @@
 					1ABFE3421B69578B003B38D8 = {
 						CreatedOnToolsVersion = 6.4;
 					};
+					98574AF22566D4B2004A2488 = {
+						CreatedOnToolsVersion = 11.3.1;
+						DevelopmentTeam = 6ZBARRDHAK;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 1ABFE33D1B69578B003B38D8 /* Build configuration list for PBXProject "ObjectiveAvro" */;
@@ -421,6 +487,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 1ABFE3391B69578B003B38D8;
@@ -429,6 +496,7 @@
 			projectRoot = "";
 			targets = (
 				1ABFE3421B69578B003B38D8 /* ObjectiveAvro */,
+				98574AF22566D4B2004A2488 /* ObjectiveAvroTests */,
 			);
 		};
 /* End PBXProject section */
@@ -438,6 +506,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		98574AF12566D4B2004A2488 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				98574B012566D7F1004A2488 /* people.json in Resources */,
+				98574B022566D7F1004A2488 /* people_schema.json in Resources */,
+				98574B032566D7F1004A2488 /* person_schema.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -496,7 +574,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		98574AEF2566D4B2004A2488 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				98574AF62566D4B2004A2488 /* ObjectiveAvroTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		98574AFA2566D4B2004A2488 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1ABFE3421B69578B003B38D8 /* ObjectiveAvro */;
+			targetProxy = 98574AF92566D4B2004A2488 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1ABFE3571B69578B003B38D8 /* Debug */ = {
@@ -630,6 +724,77 @@
 			};
 			name = Release;
 		};
+		98574AFB2566D4B2004A2488 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6ZBARRDHAK;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ObjectiveAvroTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mindstrong.KeyboardTests.ObjectiveAvroTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		98574AFC2566D4B2004A2488 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6ZBARRDHAK;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ObjectiveAvroTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mindstrong.KeyboardTests.ObjectiveAvroTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -647,6 +812,15 @@
 			buildConfigurations = (
 				1ABFE35A1B69578B003B38D8 /* Debug */,
 				1ABFE35B1B69578B003B38D8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		98574AFD2566D4B2004A2488 /* Build configuration list for PBXNativeTarget "ObjectiveAvroTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				98574AFB2566D4B2004A2488 /* Debug */,
+				98574AFC2566D4B2004A2488 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -686,6 +686,11 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"DEFLATE_CODEC=1",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -710,6 +715,8 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEFLATE_CODEC=1";
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/ObjectiveAvro.xcodeproj/xcshareddata/xcschemes/ObjectiveAvro.xcscheme
+++ b/ObjectiveAvro.xcodeproj/xcshareddata/xcschemes/ObjectiveAvro.xcscheme
@@ -37,10 +37,19 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1ABFE3421B69578B003B38D8"
+            BuildableName = "ObjectiveAvro.framework"
+            BlueprintName = "ObjectiveAvro"
+            ReferencedContainer = "container:ObjectiveAvro.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,24 +62,16 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ABFE3421B69578B003B38D8"
-            BuildableName = "ObjectiveAvro.framework"
-            BlueprintName = "ObjectiveAvro"
-            ReferencedContainer = "container:ObjectiveAvro.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -81,14 +82,12 @@
             ReferencedContainer = "container:ObjectiveAvro.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/ObjectiveAvroTests/Info.plist
+++ b/ObjectiveAvroTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -1,0 +1,540 @@
+//
+//  ObjectiveAvroTests.m
+//  ObjectiveAvroTests
+//
+//  Created by Max Zhilyaev on 11/19/20.
+//  This is a copy of Example/ObjectiveAbroTests.m with some moditications
+//  to remove Expecta stuff
+//
+
+#define EXP_SHORTHAND YES
+
+#import <XCTest/XCTest.h>
+#import <ObjectiveAvro/OAVAvroSerialization.h>
+
+@interface ObjectiveAvroTests : XCTestCase
+
+@end
+
+@implementation ObjectiveAvroTests
+
+#pragma mark - Private methods
+
++ (id)JSONObjectFromBundleResource:(NSString *)resource {
+    NSString *path = [[NSBundle bundleForClass:self] pathForResource:resource ofType:@"json"];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+
+    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    return dict;
+}
+
++ (id)stringFromBundleResource:(NSString *)resource {
+    NSString *path = [[NSBundle bundleForClass:self] pathForResource:resource ofType:@"json"];
+    return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+}
+
+- (NSString *) dictionaryToJsonString:(NSDictionary*)dict
+{
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
+                                                       options:0
+                                                         error:&error];
+    XCTAssertNotNil(jsonData);
+    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+- (void)registerSchemas:(OAVAvroSerialization *)avro {
+    NSString *personSchema = [[self class] stringFromBundleResource:@"person_schema"];
+    NSString *peopleSchema = [[self class] stringFromBundleResource:@"people_schema"];
+
+    [avro registerSchema:personSchema error:NULL];
+    [avro registerSchema:peopleSchema error:NULL];
+}
+
+#pragma mark - XCTestCase
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - Tests
+
+- (void)testValidSchemaRegistration {
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+
+    NSString *personSchema = [[self class] stringFromBundleResource:@"person_schema"];
+    NSString *peopleSchema = [[self class] stringFromBundleResource:@"people_schema"];
+
+    NSError *error;
+    BOOL result = [avro registerSchema:personSchema error:&error];
+    XCTAssert(result);
+    XCTAssertNil(error);
+
+    result = [avro registerSchema:peopleSchema error:&error];
+    XCTAssert(result);
+    XCTAssertNil(error);
+}
+
+- (void)testInvalidJSONSchemaRegistration {
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    NSError *error;
+    BOOL result = [avro registerSchema:@"{invalid json}" error:&error];
+    XCTAssertFalse(result);
+    XCTAssertNotNil(error);
+}
+
+- (void)testInvalidSchemaWithNoNameRegistration {
+    NSString *schema = @"{\"type\":\"record\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"age\",\"type\":\"int\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    NSError *error;
+    BOOL result = [avro registerSchema:schema error:&error];
+    XCTAssertFalse(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain,NSCocoaErrorDomain);
+    XCTAssertEqual(error.code,NSPropertyListReadCorruptError);
+}
+
+- (void)testAvroFileWrite {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSString *fullAvroPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"people.avro"];
+    BOOL success = [avro writeJSONObjects:@[dict]
+                                  toFile:fullAvroPath
+                          forSchemaNamed:@"People" error:&error];
+    success = [avro writeJSONObjects:@[dict]
+                              toFile:fullAvroPath
+                      forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue(success);
+
+    NSArray* seralization = [avro JSONObjectsFromFile:fullAvroPath error:&error];
+    XCTAssertTrue(seralization.count == 1);
+    // expect different, avro looking json
+    NSString* expectedJson = @"{\"people\": [{\"name\": \"Marcelo Fabri\", \"country\": {\"string\": \"Brazil\"}, \"age\": 20}, {\"name\": \"Tim Cook\", \"country\": {\"string\": \"USA\"}, \"age\": 53}, {\"name\": \"Steve Wozniak\", \"country\": {\"string\": \"USA\"}, \"age\": 63}, {\"name\": \"Bill Gates\", \"country\": {\"string\": \"USA\"}, \"age\": 58}, {\"name\": \"Stateless Johnny\", \"country\": null, \"age\": 104}], \"generated_timestamp\": 1389376800000}";
+    XCTAssertEqualObjects(seralization[0], expectedJson);
+}
+
+- (void)testAvroFileReopen {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"people.avro"];
+    NSLog(@"writing to %@", filePath);
+    OAVFileWriterToken token = [avro startFile:filePath forSchemaNamed:@"People" error:&error];
+    XCTAssertNil(error);
+
+    BOOL success = [avro writeJSONObjects:@[dict] toWriter:token
+                           forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue(success);
+
+    [avro closeFile:token];
+
+    token = [avro openFile:filePath error:&error];
+
+    XCTAssertNil(error);
+
+    success = [avro writeJSONObjects:@[dict] toWriter:token
+                           forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue(success);
+
+    [avro closeFile:token];
+
+    NSArray* seralization = [avro JSONObjectsFromFile:filePath error:&error];
+    XCTAssertTrue(seralization.count == 2);
+
+    for (int i=0; i < 2; i++) {
+        NSString* expectedJson = @"{\"people\": [{\"name\": \"Marcelo Fabri\", \"country\": {\"string\": \"Brazil\"}, \"age\": 20}, {\"name\": \"Tim Cook\", \"country\": {\"string\": \"USA\"}, \"age\": 53}, {\"name\": \"Steve Wozniak\", \"country\": {\"string\": \"USA\"}, \"age\": 63}, {\"name\": \"Bill Gates\", \"country\": {\"string\": \"USA\"}, \"age\": 58}, {\"name\": \"Stateless Johnny\", \"country\": null, \"age\": 104}], \"generated_timestamp\": 1389376800000}";
+        XCTAssertEqualObjects(seralization[0], expectedJson);
+
+    }
+
+}
+
+- (void)testAvroSerialization {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSDictionary *fromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(fromAvro);
+}
+
+- (void)testAvroCopy {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    OAVAvroSerialization *copy = [avro copy];
+    XCTAssertNotNil(copy);
+    XCTAssertNotEqualObjects(copy,avro);
+
+    NSData *dataFromCopy = [copy dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(dataFromCopy);
+    XCTAssertEqualObjects(dataFromCopy,data);
+}
+
+- (void)testAvroCoding {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSData *archivedAvroData = [NSKeyedArchiver archivedDataWithRootObject:avro];
+    XCTAssertNotNil(archivedAvroData);
+
+    OAVAvroSerialization *archivedAvro = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAvroData];
+
+    XCTAssertNotNil(archivedAvro);
+
+    NSData *dataFromCopy = [archivedAvro dataFromJSONObject:dict
+                                             forSchemaNamed:@"People" error:&error];
+    
+    XCTAssertEqualObjects(dataFromCopy, data);
+    XCTAssertNil(error);
+    XCTAssertNotNil(dataFromCopy);
+    XCTAssertEqualObjects(dataFromCopy,data);
+}
+
+// we should fail, but schema validation doesn't seem to work correctly
+//  @TODO - https://mindstronghealth.atlassian.net/browse/HEALTH-5227
+- (void)testMissingFieldAvroSerialization {
+    NSString *json = @"{\"people\":[{\"name\":\"Marcelo Fabri\"},{\"name\":\"Tim Cook\",\"country\":\"USA\",\"age\":53},{\"name\":\"Steve Wozniak\",\"country\":\"USA\",\"age\":63},{\"name\":\"Bill Gates\",\"country\":\"USA\",\"age\":58}],\"generated_timestamp\":1389376800000}";
+
+    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:[json dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain,NSCocoaErrorDomain);
+    XCTAssertEqual(error.code,NSPropertyListReadCorruptError);
+    XCTAssertNil(data);
+}
+
+- (void)testNoSchemaRegistred {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain,NSCocoaErrorDomain);
+    XCTAssertEqual(error.code,NSFileReadNoSuchFileError);
+    XCTAssertNil(data);
+}
+
+#pragma mark - Type tests
+
+- (void)testStringType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"StringTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"string_value\",\"type\":\"string\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *strings = @[@"bla", @"test", @"foo", @"bar"];
+
+    for (NSString *str in strings) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"string_value": str} forSchemaNamed:@"StringTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *strFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"StringTest" error:&error][@"string_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(strFromAvro,str);
+    }
+}
+
+- (void)testIntType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"IntTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"int_value\",\"type\":\"int\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000, @-200, @-100001, @0];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"int_value": number} forSchemaNamed:@"IntTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"IntTest" error:&error][@"int_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(numberFromAvro,number);
+    }
+}
+
+- (void)testLongType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"LongTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"long_value\",\"type\":\"long\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000,  @-200, @-100001, @0, @((long) pow(2, 30)), @((long) pow(-2, 30))];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"long_value": number} forSchemaNamed:@"LongTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"LongTest" error:&error][@"long_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(numberFromAvro,number);
+    }
+}
+
+- (void)testFloatType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"FloatTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"float_value\",\"type\":\"float\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000, @-200, @-100001, @0, @1.43f, @100.98420f, @0.001f, @-9.7431f];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"float_value": number} forSchemaNamed:@"FloatTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"FloatTest" error:&error][@"float_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualWithAccuracy([numberFromAvro floatValue], [number floatValue], 0.01);
+    }
+}
+
+- (void)testDoubleType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"DoubleTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"double_value\",\"type\":\"double\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000, @-200, @-100001, @0, @1.43, @100.98420, @0.001, @-9.7431, @(DBL_MAX), @((double) pow(2.4, 20)), @(M_PI)];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"double_value": number} forSchemaNamed:@"DoubleTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"DoubleTest" error:&error][@"double_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(numberFromAvro,number);
+    }
+}
+
+- (void)testBooleanType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"BooleanTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"boolean_value\",\"type\":\"boolean\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@NO, @YES];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"boolean_value": number} forSchemaNamed:@"BooleanTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"BooleanTest" error:&error][@"boolean_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqual(numberFromAvro,number);
+    }
+}
+
+- (void)testNullType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"NullTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"null_value\",\"type\":\"null\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"null_value": [NSNull null]} forSchemaNamed:@"NullTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"NullTest" error:&error][@"null_value"];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(nullFromAvro, [NSNull null]);
+}
+
+- (void)testArrayType {
+    NSString *schema = @"{\"type\":\"array\",\"name\":\"ArrayTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"items\": {\"type\": \"int\"}}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSArray *array = @[@1, @5, @-2, @0, @10021, @500000];
+    NSData *data = [avro dataFromJSONObject:array forSchemaNamed:@"ArrayTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSArray *arrayFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"ArrayTest" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(arrayFromAvro,array);
+}
+
+- (void)testMapType {
+    NSString *schema = @"{\"type\":\"map\",\"name\":\"MapTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"values\": \"int\"}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSDictionary *map = @{@"one": @1, @"zero": @0, @"two": @2, @"-one": @-1};
+    NSData *data = [avro dataFromJSONObject:map forSchemaNamed:@"MapTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSDictionary *mapFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"MapTest" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(mapFromAvro,map);
+}
+
+- (void)testBytesType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"BytesTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"bytes_value\",\"type\":\"bytes\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSString *bytes = @"\"\\u00de\\u00ad\\u00be\\u00ef\"";
+
+    NSData *data = [avro dataFromJSONObject:@{@"bytes_value": bytes} forSchemaNamed:@"BytesTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id bytesFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"BytesTest" error:&error][@"bytes_value"];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(bytesFromAvro,bytes);
+}
+
+- (void)testUnionType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"null\", \"string\"],  \"default\": null}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"union_value": [NSNull null]} forSchemaNamed:@"UnionTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(nullFromAvro, [NSNull null]);
+
+    data = [avro dataFromJSONObject:@{@"union_value": @"Tibet"} forSchemaNamed:@"UnionTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id stringFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(stringFromAvro, @{@"string": @"Tibet"});
+}
+
+- (void)testDefault {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"int\", \"string\"], \"default\": 10}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"no_default": @"hey"} forSchemaNamed:@"UnionTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(numberFromAvro, @{@"int": @10});
+}
+
+- (void)testNullDefault {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"NumericDefaultTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"test\",\"type\":[\"null\", \"long\"], \"default\": null}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"test": @10} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    data = [avro dataFromJSONObject:@{@"test": [NSNull null]} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+}
+
+@end

--- a/ObjectiveAvroTests/people.json
+++ b/ObjectiveAvroTests/people.json
@@ -1,0 +1,30 @@
+{
+    "people": [
+        {
+            "name": "Marcelo Fabri",
+            "country": "Brazil",
+            "age": 20
+        },
+        {
+            "name": "Tim Cook",
+            "country": "USA",
+            "age": 53
+        },
+        {
+            "name": "Steve Wozniak",
+            "country": "USA",
+            "age": 63
+        },
+        {
+            "name": "Bill Gates",
+            "country": "USA",
+            "age": 58
+        },
+        {
+            "name": "Stateless Johnny",
+            "country": null,
+            "age": 104
+        }
+    ],
+    "generated_timestamp": 1389376800000
+}

--- a/ObjectiveAvroTests/people_schema.json
+++ b/ObjectiveAvroTests/people_schema.json
@@ -1,0 +1,35 @@
+{
+    "type": "record",
+    "name": "People",
+    "namespace": "com.movile.objectiveavro.unittest.v1",
+    "fields": [
+        {
+            "name": "people",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "Person",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "country",
+                            "type": ["null", "string"]
+                        },
+                        {
+                            "name": "age",
+                            "type": "int"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "generated_timestamp",
+            "type": "long"
+        }
+    ]
+}

--- a/ObjectiveAvroTests/person_schema.json
+++ b/ObjectiveAvroTests/person_schema.json
@@ -1,0 +1,19 @@
+{
+    "type": "record",
+    "name": "Person",
+    "namespace": "com.movile.objectiveavro.unittest.v1",
+    "fields": [
+        {
+            "name": "name",
+            "type": "string"
+        },
+        {
+            "name": "country",
+            "type": ["null", "string"]
+        },
+        {
+            "name": "age",
+            "type": "int"
+        }
+    ]
+}


### PR DESCRIPTION
- added JSONObjectsFromFile method to allow reading from avro files in tests
- ported Example unit tests to the top ObjectiveAvro framework level
- reverted "HEALTH-3536: write file with codec deflate" commit and added appropriate pre-processor symbol to enable deflate codec in debug and release modes